### PR TITLE
WIP - Add a flag to work (list/deploy) based on binary version

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -87,12 +87,17 @@ func (d *Deploy) execute() error {
 	}
 
 	// If the branch is null it will use the default one.
-	sha1ToDeploy, err := d.Context.Vcs.RetrieveSha1ForProject(branch)
-	if err != nil {
-		return errors.New(fmt.Sprintf("Failed to retrieve source changes for %q : %q", d.Service, err))
+	var podVersion string
+	var sha1ToDeploy string
+	if d.Context.GetVersionFromVcs {
+		sha1ToDeploy, err = d.Context.Vcs.RetrieveSha1ForProject(branch)
+		if err != nil {
+			return errors.New(fmt.Sprintf("Failed to retrieve source changes for %q : %q", d.Service, err))
+		}
+		podVersion, err = d.Context.Binaries.RetrievePodVersion(sha1ToDeploy)
+	} else {
+		podVersion, err = d.Context.Binaries.RetrievePodVersion("")
 	}
-
-	podVersion, err := d.Context.Binaries.RetrievePodVersion(sha1ToDeploy)
 	if err != nil {
 		return errors.New(fmt.Sprintf("Failed to retrieve pod version: %q", err))
 	}

--- a/context/context.go
+++ b/context/context.go
@@ -15,6 +15,7 @@ import (
 type Context struct {
 	Deployer          deployers.Deployer
 	Vcs               services.Sources
+	GetVersionFromVcs bool
 	Binaries          services.Binaries
 	Hooks             []hooks.Hooks
 	LockSystem        utils.Lock
@@ -68,6 +69,11 @@ func NewContext(cfg *utils.Config, manifest *utils.Manifest) (*Context, error) {
 			"Vcs unknown : %q",
 			manifest.VcsManifest,
 		)
+	}
+
+	ctx.GetVersionFromVcs = true
+	if cfg.VcsConfig.UseForVersion == false {
+		ctx.GetVersionFromVcs = false
 	}
 
 	if manifest.BinariesManifest.NexusManifest != (utils.NexusManifest{}) {

--- a/deployers/k8s.go
+++ b/deployers/k8s.go
@@ -36,7 +36,11 @@ func NewDeployerK8s(cfg utils.DeployerK8sConfig, manifest utils.DeployerK8sManif
 	deployer.Namespace = manifest.Namespace
 	deployer.Environments = cfg.Environments
 	deployer.workPath = cfg.WorkPath
-	deployer.vcsRegexp = cfg.VcsRegexp
+	if manifest.VcsRegexp != "" {
+		deployer.vcsRegexp = manifest.VcsRegexp
+	} else {
+		deployer.vcsRegexp = cfg.VcsRegexp
+	}
 	return &deployer, nil
 }
 

--- a/utils/config.go
+++ b/utils/config.go
@@ -44,7 +44,8 @@ type DeployerGgnConfig struct {
 }
 
 type VcsConfig struct {
-	StashConfig `mapstructure:"stash"`
+	StashConfig   `mapstructure:"stash"`
+	UseForVersion bool `mapstructure:"use_for_version"`
 }
 
 type StashConfig struct {

--- a/utils/manifest.go
+++ b/utils/manifest.go
@@ -32,6 +32,7 @@ type DeployerManifest struct {
 type DeployerK8sManifest struct {
 	Release   string `mapstructure:"release"`
 	Namespace string `mapstructure:"namespace"`
+	VcsRegexp string `mapstructure:"vcsRegexp"`
 }
 
 type DeployerGgnManifest struct {


### PR DESCRIPTION

Here a proposal to extend contactkey manifest in order to be able with versioning only based binaries.
Also, added the vcsRegexp flag into k8s deployer.

Need to finish this (test / code conventions) but thought it might be interesting.