### PR TITLE
Make force override ListVcsVersions

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -99,7 +99,12 @@ func (d *Deploy) execute() error {
 
 	deployedVersions, err := d.Context.Deployer.ListVcsVersions(d.Env)
 	if err != nil {
-		return errors.New(fmt.Sprintf("Failed to retrieve DEPLOYED version from service(%q) in env %q: %q", d.Service, d.Env, err))
+		message := fmt.Sprintf("Failed to retrieve DEPLOYED version from service(%q) in env %q: %q", d.Service, d.Env, err)
+		if force {
+			log.Println(message)
+		} else {
+			return errors.New(message)
+		}
 	}
 
 	if podVersion == "" {


### PR DESCRIPTION
Usage : 
  When actual deployment/values is corrupted (tag: ~ returned from tiller), ListVcsVersions fail and it is impossible to redeploy.